### PR TITLE
Fix Microsoft Entra ID toml in example to match required field

### DIFF
--- a/docs/versioned_docs/version-7.8.x/configuration/providers/ms_entra_id.md
+++ b/docs/versioned_docs/version-7.8.x/configuration/providers/ms_entra_id.md
@@ -192,6 +192,6 @@ client_id="<client-id>"
 client_secret="<client-secret>"
 insecure_oidc_skip_issuer_verification=true
 scope="openid profile email User.Read"
-entra_id_allowed_tenant=["9188040d-6c67-4c5b-b112-36a304b66dad","<my-tenant-id>"] # Allow only <my-tenant-id> and Personal MS Accounts tenant 
+entra_id_allowed_tenants=["9188040d-6c67-4c5b-b112-36a304b66dad","<my-tenant-id>"] # Allow only <my-tenant-id> and Personal MS Accounts tenant 
 email_domains="*"
 ```


### PR DESCRIPTION
The Toml field required is the plural "entra_id_allowed_tenants" as listed in the top section under Config Options. However, the sample at the bottom lists the singular "entra_id_allwed_tenant" which has a parse failure. Fix this so folks doing copy/paste like I was don't have to trip over this.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [ ] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
